### PR TITLE
build fixes: support other aarch64 linux distros

### DIFF
--- a/cmake/linux_config.cmake
+++ b/cmake/linux_config.cmake
@@ -44,7 +44,7 @@ endif()
 execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_VARIABLE MACHINE)
 
 if(OB_BUILD_LINUX_ARM64)
-    if(${MACHINE} MATCHES "aarch64-linux-gnu")
+    if(${MACHINE} MATCHES "aarch64-([a-zA-Z0-9]+-)?linux-gnu")
         add_definitions(-DOS_ARM)
         add_definitions(-DOS_ARM64)
         set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS}  -Wl,--allow-shlib-undefined -mstrict-align -ftree-vectorize")

--- a/src/platform/usb/uvc/ObV4lGmslDevicePort.cpp
+++ b/src/platform/usb/uvc/ObV4lGmslDevicePort.cpp
@@ -394,7 +394,8 @@ void foreachProfileGmsl(std::vector<std::shared_ptr<V4lDeviceHandleGmsl>>       
                                 // LOG_DEBUG("-devHandle->fd:{0}, -format:{1}, width:{2}, heigh:{3}, fps:{4}, mStreamType:{5}, fdPnum:{6}", devHandle->fd,
                                 // format, width, height, fps, mStreamType, fdPnum );
                                 // auto profile = std::make_shared<VideoStreamProfile>(OB_STREAM_VIDEO, format, width, height, fps);
-                                auto profile = std::make_shared<VideoStreamProfile>(std::shared_ptr<LazySensor>(), mStreamType, format, width, height, fps);
+                                auto profile = std::make_shared<VideoStreamProfile>(std::shared_ptr<LazySensor>(), static_cast<OBStreamType>(mStreamType),
+                                                                                    format, width, height, fps);
                                 if(fourcc != 0) {
                                     quit = func(devHandle, profile);
                                 }


### PR DESCRIPTION
- Change the CMake regex so that it can accept e.g.

    aarch64-redhat-linux-gnu

- An enum needed a cast to the right type with clang-19
