### PR TITLE
Generating OrbbecSDKConfigVersion.cmake file

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,17 @@ if(OB_IS_MAIN_PROJECT)
     )
 
     install(EXPORT OrbbecSDKConfig NAMESPACE ob:: DESTINATION lib)
+
+    include(CMakePackageConfigHelpers)
+    write_basic_package_version_file(
+        "${CMAKE_CURRENT_BINARY_DIR}/OrbbecSDKConfigVersion.cmake"
+        VERSION "${PROJECT_VERSION}"
+        COMPATIBILITY AnyNewerVersion
+    )
+    install(
+        FILES "${CMAKE_CURRENT_BINARY_DIR}/OrbbecSDKConfigVersion.cmake"
+        DESTINATION lib
+    )
 endif()
 
 if(OB_BUILD_SOVERSION)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -87,7 +87,7 @@ if(OB_IS_MAIN_PROJECT)
     write_basic_package_version_file(
         "${CMAKE_CURRENT_BINARY_DIR}/OrbbecSDKConfigVersion.cmake"
         VERSION "${PROJECT_VERSION}"
-        COMPATIBILITY AnyNewerVersion
+        COMPATIBILITY SameMajorVersion
     )
     install(
         FILES "${CMAKE_CURRENT_BINARY_DIR}/OrbbecSDKConfigVersion.cmake"


### PR DESCRIPTION
# Summary
The PR adds cmake code to generate a standard `OrbbecSDKConfigVersion.cmake`, useful when requesting a specific package version from downstream projects including the library with cmake: `find_package(OrbbecSDK 2 REQUIRED)`. Because the [OrbbecSDK v1](https://github.com/orbbec/OrbbecSDK/blob/main/OrbbecSDKConfig.cmake) library shares exactly the same package name, the only way downstream to differentiate the versions with cmake is by using the standard approach as above.

# Current issue that this PR solves
If in a downstream project we do:
```cmake
find_package(OrbbecSDK)
```
We may end up with either OrbbecSDK v1 or OrbbecSDK v2 target, if both are installed at the same time.

If we do instead:
```cmake
find_package(OrbbecSDK 2 REQUIRED)
```
we would get error like this (even if OrbbecSDK v2 is installed):
```bash
$ cmake -DOrbbecSDK_DIR=/opt/OrbbecSDK/lib ..

CMake Error at CMakeLists.txt:703 (FIND_PACKAGE):
  Could not find a configuration file for package "OrbbecSDK" that is
  compatible with requested version "2".

  The following configuration files were considered but not accepted:

    /opt/OrbbecSDK/lib/OrbbecSDKConfig.cmake, version: unknown
```

# Results with this PR
With:
```cmake
find_package(OrbbecSDK 2 REQUIRED)
message(STATUS "Found OrbbecSDK ${OrbbecSDK_VERSION}")
```
we then get:
```bash
$ cmake -DOrbbecSDK_DIR=/opt/OrbbecSDK/lib ..

...
-- Found OrbbecSDK 2.4.11
...
```
