### PR TITLE
Fixing Global timestamps in tools/benchmark

### DIFF
--- a/tools/benchmark/src/DeviceResource.cpp
+++ b/tools/benchmark/src/DeviceResource.cpp
@@ -10,6 +10,10 @@ DeviceResource::DeviceResource(std::shared_ptr<ob::Device> device) : device_(dev
     align_filter_       = std::make_shared<ob::Align>(OB_STREAM_COLOR);
     point_cloud_filter_ = std::make_shared<ob::PointCloudFilter>();
 
+    if(device_ != nullptr and device_->isGlobalTimestampSupported()) {
+        device_->enableGlobalTimestamp(true);
+    }
+
     resetConfig();
 }
 


### PR DESCRIPTION
This PR fixes this issue: https://github.com/orbbec/OrbbecSDK_v2/issues/139

Currently, the GlobalTimestamps of the reports provided by this tool are all zeroes, this is because GlobalTimestamps are not being enabled before being used. This PR fixes this issue by enabling them.

## Before
[summary.csv](https://github.com/user-attachments/files/25102660/summary.csv)
[0.csv](https://github.com/user-attachments/files/25102657/0.csv)
[AARK753002H_timestamp_difference_depth.csv](https://github.com/user-attachments/files/25102658/AARK753002H_timestamp_difference_depth.csv)
[AARK753002H_timestamp_difference_color.csv](https://github.com/user-attachments/files/25102659/AARK753002H_timestamp_difference_color.csv)

## After
[summary.csv](https://github.com/user-attachments/files/25102726/summary.csv)
[0.csv](https://github.com/user-attachments/files/25102723/0.csv)
[AARK753002H_timestamp_difference_depth.csv](https://github.com/user-attachments/files/25102725/AARK753002H_timestamp_difference_depth.csv)
[AARK753002H_timestamp_difference_color.csv](https://github.com/user-attachments/files/25102724/AARK753002H_timestamp_difference_color.csv)
