### PR TITLE
GlobalTimestampFitter: custom host timestamp

### DIFF
--- a/include/libobsensor/h/Device.h
+++ b/include/libobsensor/h/Device.h
@@ -247,6 +247,47 @@ OB_EXPORT bool ob_device_is_global_timestamp_supported(const ob_device *device, 
 OB_EXPORT void ob_device_enable_global_timestamp(ob_device *device, bool enable, ob_error **error);
 
 /**
+ * @brief Replace the host clock source used by the global timestamp fitter.
+ *
+ * The default is the SDK's internal std::chrono::system_clock-based clock.
+ * Callers that want frame timestamps in a different domain (e.g. a monotonic
+ * application clock) install their own function here. Safe to call before or
+ * while the fitter is enabled; any pending samples are discarded so the next
+ * sample iteration begins in the new domain.
+ *
+ * @param[in] device The device object.
+ * @param[in] fn The host clock callback, or NULL to restore the SDK default.
+ * @param[in] user_data Opaque pointer passed verbatim to `fn` on every call.
+ *                      The caller must keep `user_data` valid for as long as
+ *                      `fn` may be invoked (i.e. until the device is destroyed
+ *                      or this function is called again).
+ * @param[out] error Pointer to an error object that will be set if an error occurs.
+ */
+OB_EXPORT void ob_device_set_global_timestamp_host_clock_fn(ob_device *device, ob_host_clock_fn fn, void *user_data, ob_error **error);
+
+/**
+ * @brief Set the maximum acceptable round-trip time of a device-time query
+ * used as a fit sample. Samples exceeding this are discarded.
+ *
+ * @param[in] device The device object.
+ * @param[in] max_rtt_us Upper bound, in microseconds.
+ * @param[out] error Pointer to an error object that will be set if an error occurs.
+ */
+OB_EXPORT void ob_device_set_global_timestamp_max_rtt_us(ob_device *device, uint64_t max_rtt_us, ob_error **error);
+
+/**
+ * @brief Read the current linear fit from the global timestamp fitter.
+ *
+ * Useful for observability and for detecting the pre-convergence state
+ * (all-zero fields indicates no fit yet).
+ *
+ * @param[in] device The device object.
+ * @param[out] out_param The fit parameters. Must not be NULL.
+ * @param[out] error Pointer to an error object that will be set if an error occurs.
+ */
+OB_EXPORT void ob_device_get_global_timestamp_linear_param(const ob_device *device, ob_linear_func_param *out_param, ob_error **error);
+
+/**
  * @brief Update the device firmware.
  *
  * @param[in] device The device object.

--- a/include/libobsensor/h/ObTypes.h
+++ b/include/libobsensor/h/ObTypes.h
@@ -383,6 +383,20 @@ typedef struct {
 } OBDataChunk, ob_data_chunk;
 
 /**
+ * @brief Coefficients of the global-timestamp linear fit `host_us = a * device_us + b`.
+ *
+ * Returned by ob_device_get_global_timestamp_linear_param. All fields are zero
+ * until the fitter has collected enough samples to fit (typically a few
+ * seconds after enabling the global timestamp).
+ */
+typedef struct {
+    double   coefficient_a;  ///< Slope of the fit
+    double   constant_b;     ///< Intercept of the fit
+    uint64_t check_data_x;   ///< Most recent device-time sample fed into the fit (x)
+    uint64_t check_data_y;   ///< Host-time partner of check_data_x (y)
+} OBLinearFuncParam, ob_linear_func_param;
+
+/**
  * @brief Structure for integer range
  */
 typedef struct {
@@ -2147,6 +2161,19 @@ typedef void (*ob_playback_status_changed_callback)(ob_playback_status status, v
  * @param[in] user_data User-defined data
  */
 typedef void (*ob_pipeline_status_callback)(ob_pipeline_status status, void *user_data);
+
+/**
+ * @brief Host clock callback signature for the global timestamp fitter.
+ *
+ * Returns the current host time in microseconds, in whatever clock domain the
+ * caller wants device timestamps mapped into. The fitter pairs the value with
+ * a device-time query to build a linear `device -> host` fit.
+ *
+ * @param[in] user_data The opaque pointer passed alongside the function pointer
+ *                      when registering the callback.
+ * @return The current host time in microseconds.
+ */
+typedef uint64_t (*ob_host_clock_fn)(void *user_data);
 
 /**
  * @brief Callback Id

--- a/src/device/IFrameTimestamp.hpp
+++ b/src/device/IFrameTimestamp.hpp
@@ -5,6 +5,8 @@
 
 #include <IFrame.hpp>
 
+#include <functional>
+
 namespace libobsensor {
 class IFrameTimestampCalculator {
 public:
@@ -22,8 +24,13 @@ typedef struct {
     uint64_t checkDataY;
 } LinearFuncParam;
 
+// Returns the current host time in microseconds, in whatever clock domain the
+// caller wants the fitter to map device timestamps into. Default is the SDK's
+// std::chrono::system_clock-based getNowTimesUs(); callers may inject a
+// monotonic source (e.g. steady_clock or a host application's clock).
+using HostClockFn = std::function<uint64_t()>;
+
 class IGlobalTimestampFitter {
-public:
 public:
     virtual ~IGlobalTimestampFitter() = default;
 
@@ -40,6 +47,16 @@ public:
 
     virtual void enable(bool en)   = 0;
     virtual bool isEnabled() const = 0;
+
+    // Replace the host clock source used to pair host time with device time.
+    // Safe to call while the fitter is running; the implementation must clear
+    // any in-flight samples so the next iteration starts in the new domain.
+    virtual void setHostClockFn(HostClockFn fn) = 0;
+
+    // Upper bound on the host-side RTT of a device-time query that the fitter
+    // is willing to accept as a sample. Higher RTTs are discarded. In
+    // microseconds. Default is the implementation's compile-time constant.
+    virtual void setMaxValidRtt(uint64_t maxValidUs) = 0;
 };
 
 }  // namespace libobsensor

--- a/src/device/component/timestamp/GlobalTimestampFitter.cpp
+++ b/src/device/component/timestamp/GlobalTimestampFitter.cpp
@@ -24,7 +24,12 @@ const std::string &GlobalTimestampFitter::GetCurrentSN() const {
 }
 
 GlobalTimestampFitter::GlobalTimestampFitter(IDevice *owner)
-    : DeviceComponentBase(owner), enable_(false), sampleLoopExit_(false), linearFuncParam_({ 0, 0, 0, 0 }), maxValidRtt_(MAX_VALID_RTT) {
+    : DeviceComponentBase(owner),
+      enable_(false),
+      sampleLoopExit_(false),
+      linearFuncParam_({ 0, 0, 0, 0 }),
+      maxValidRtt_(MAX_VALID_RTT),
+      hostClockFn_(&utils::getNowTimesUs) {
     std::string deviceName = utils::string::removeSpace(owner->getInfo()->name_);
     auto        envConfig  = EnvConfig::getInstance();
     int         value      = 0;
@@ -108,8 +113,27 @@ void GlobalTimestampFitter::resume() {
     }
 }
 
-void GlobalTimestampFitter::setMaxValidRtt(uint64_t maxValidTime) {
-    maxValidRtt_ = maxValidTime;
+void GlobalTimestampFitter::setMaxValidRtt(uint64_t maxValidUs) {
+    maxValidRtt_ = maxValidUs;
+}
+
+void GlobalTimestampFitter::setHostClockFn(HostClockFn fn) {
+    if(!fn) {
+        fn = &utils::getNowTimesUs;
+    }
+    {
+        std::unique_lock<std::mutex> lock(hostClockFnMutex_);
+        hostClockFn_ = std::move(fn);
+    }
+    // Any samples already in the queue were taken in the previous clock domain;
+    // mixing them with the new domain would produce garbage in the linear fit.
+    // Clear and force a refit on the next sample iteration.
+    {
+        std::unique_lock<std::mutex> lock(sampleMutex_);
+        samplingQueue_.clear();
+        needCalculation_ = true;
+        sampleCondVar_.notify_one();
+    }
 }
 
 void GlobalTimestampFitter::enable(bool en) {
@@ -206,9 +230,19 @@ bool GlobalTimestampFitter::ensureFitting() {
         std::unique_lock<std::mutex> lock(sampleMutex_);
         while(samplingQueue_.size() < 6 && count < 6) {
             ++count;
-            auto sysTsp1Usec = utils::getNowTimesUs();
-            devTime          = propertyServer->getStructureDataT<OBDeviceTime>(OB_STRUCT_DEVICE_TIME);
-            auto sysTsp2Usec = utils::getNowTimesUs();
+            uint64_t sysTsp1Usec;
+            uint64_t sysTsp2Usec;
+            {
+                // Hold hostClockFnMutex_ across the entire bracket so a concurrent
+                // setHostClockFn cannot return until this sample finishes. This is
+                // what lets callers safely free old closure storage after the
+                // setter returns. Cost: ~RTT of one device-time query (typically
+                // a few ms) of contention with the setter.
+                std::unique_lock<std::mutex> hostFnLock(hostClockFnMutex_);
+                sysTsp1Usec = hostClockFn_();
+                devTime     = propertyServer->getStructureDataT<OBDeviceTime>(OB_STRUCT_DEVICE_TIME);
+                sysTsp2Usec = hostClockFn_();
+            }
             sysTspUsec       = (sysTsp2Usec + sysTsp1Usec) / 2;
             devTime.rtt      = sysTsp2Usec - sysTsp1Usec;
             if(devTime.rtt > maxValidRtt_) {
@@ -257,9 +291,15 @@ void GlobalTimestampFitter::fittingLoop() {
             auto owner          = getOwner();
             auto propertyServer = owner->getPropertyServer();
 
-            auto sysTsp1Usec = utils::getNowTimesUs();
-            devTime          = propertyServer->getStructureDataT<OBDeviceTime>(OB_STRUCT_DEVICE_TIME);
-            auto sysTsp2Usec = utils::getNowTimesUs();
+            uint64_t sysTsp1Usec;
+            uint64_t sysTsp2Usec;
+            {
+                // See ensureFitting() for why this mutex is held across the property query.
+                std::unique_lock<std::mutex> hostFnLock(hostClockFnMutex_);
+                sysTsp1Usec = hostClockFn_();
+                devTime     = propertyServer->getStructureDataT<OBDeviceTime>(OB_STRUCT_DEVICE_TIME);
+                sysTsp2Usec = hostClockFn_();
+            }
             sysTspUsec       = (sysTsp2Usec + sysTsp1Usec) / 2;
             devTime.rtt      = sysTsp2Usec - sysTsp1Usec;
             if(devTime.rtt > maxValidRtt_) {

--- a/src/device/component/timestamp/GlobalTimestampFitter.hpp
+++ b/src/device/component/timestamp/GlobalTimestampFitter.hpp
@@ -22,7 +22,8 @@ public:
     void            reFitting(bool async) override;
     void            pause() override;
     void            resume() override;
-    void            setMaxValidRtt(uint64_t maxValidTime);
+    void            setMaxValidRtt(uint64_t maxValidUs) override;
+    void            setHostClockFn(HostClockFn fn) override;
 
     void enable(bool en) override;
     bool isEnabled() const override;
@@ -59,5 +60,8 @@ private:
     LinearFuncParam         linearFuncParam_;
     uint64_t                lastCheckDataY = 0;
     uint64_t                maxValidRtt_;
+
+    std::mutex  hostClockFnMutex_;
+    HostClockFn hostClockFn_;
 };
 }  // namespace libobsensor

--- a/src/impl/Device.cpp
+++ b/src/impl/Device.cpp
@@ -523,6 +523,37 @@ void ob_device_enable_global_timestamp(ob_device *device, bool enable, ob_error 
 }
 HANDLE_EXCEPTIONS_NO_RETURN(device, enable)
 
+void ob_device_set_global_timestamp_host_clock_fn(ob_device *device, ob_host_clock_fn fn, void *user_data, ob_error **error) BEGIN_API_CALL {
+    VALIDATE_NOT_NULL(device);
+    auto globalTimestampFilter = device->device->getComponentT<libobsensor::IGlobalTimestampFitter>(libobsensor::OB_DEV_COMPONENT_GLOBAL_TIMESTAMP_FILTER);
+    if(fn == nullptr) {
+        globalTimestampFilter->setHostClockFn(libobsensor::HostClockFn{});
+    }
+    else {
+        globalTimestampFilter->setHostClockFn([fn, user_data]() -> uint64_t { return fn(user_data); });
+    }
+}
+HANDLE_EXCEPTIONS_NO_RETURN(device, fn, user_data)
+
+void ob_device_set_global_timestamp_max_rtt_us(ob_device *device, uint64_t max_rtt_us, ob_error **error) BEGIN_API_CALL {
+    VALIDATE_NOT_NULL(device);
+    auto globalTimestampFilter = device->device->getComponentT<libobsensor::IGlobalTimestampFitter>(libobsensor::OB_DEV_COMPONENT_GLOBAL_TIMESTAMP_FILTER);
+    globalTimestampFilter->setMaxValidRtt(max_rtt_us);
+}
+HANDLE_EXCEPTIONS_NO_RETURN(device, max_rtt_us)
+
+void ob_device_get_global_timestamp_linear_param(const ob_device *device, ob_linear_func_param *out_param, ob_error **error) BEGIN_API_CALL {
+    VALIDATE_NOT_NULL(device);
+    VALIDATE_NOT_NULL(out_param);
+    auto globalTimestampFilter = device->device->getComponentT<libobsensor::IGlobalTimestampFitter>(libobsensor::OB_DEV_COMPONENT_GLOBAL_TIMESTAMP_FILTER);
+    auto param                 = globalTimestampFilter->getLinearFuncParam();
+    out_param->coefficient_a   = param.coefficientA;
+    out_param->constant_b      = param.constantB;
+    out_param->check_data_x    = param.checkDataX;
+    out_param->check_data_y    = param.checkDataY;
+}
+HANDLE_EXCEPTIONS_NO_RETURN(device, out_param)
+
 void ob_device_update_firmware(ob_device *device, const char *path, ob_device_fw_update_callback callback, bool async, void *user_data,
                                ob_error **error) BEGIN_API_CALL {
     VALIDATE_NOT_NULL(device);


### PR DESCRIPTION
This change allows the SDK user to provide a custom timestamp function. The current default timestamp function gets the global time, which is subject to NTP updates. Some users (e.g. me) might want to replace the estimated timestamp with their own function so that we can use a monotonic time source.

`IGlobalTimestampFitter` gets two new methods:
- `setHostClockFn`: replace the default clock function with a custom one
- `setMaxValidRtt`: now exposed in the interface, the max RTT before discarding a time sample.

`HostClockFn` is expected to return a microsecond time value.

The new functionality is also exposed in the C API.