### PR TITLE
Register `DeviceActivityRecorder` on all net devices

### DIFF
--- a/src/device/DeviceBase.cpp
+++ b/src/device/DeviceBase.cpp
@@ -14,6 +14,7 @@
 #include "IDeviceMonitor.hpp"
 #include "utils/DeviceTypeHelper.hpp"
 #include "component/comprehensivefilter/DepthPostFilterParamsManager.hpp"
+#include "component/monitor/DeviceActivityRecorder.hpp"
 
 #ifdef __linux__
 #include "usb/uvc/UvcDevicePort.hpp"
@@ -55,6 +56,21 @@ void DeviceBase::postInitialize() {
     activateDeviceAccessor();
     // load default post processing config
     loadDefaultPostProcessingConfig();
+
+    // Register the device activity recorder for all net devices.
+    // `NetDeviceEnumerator::handleDeviceRemoved` checks the activity recorder
+    // to determine if a device is offline before removing it, so temporary
+    // GVCP discovery failures do not deactivate streaming devices.
+    if(enumInfo_ && enumInfo_->getConnectionType() == "Ethernet") {
+        registerComponent(
+            OB_DEV_COMPONENT_DEVICE_ACTIVITY_RECORDER,
+            [this]() {
+                std::shared_ptr<DeviceActivityRecorder> activityRecorder;
+                TRY_EXECUTE({ activityRecorder = std::make_shared<DeviceActivityRecorder>(this); })
+                return activityRecorder;
+            },
+            false);
+    }
 }
 
 void DeviceBase::fetchDeviceInfo() {

--- a/src/device/gemini330/G330Device.cpp
+++ b/src/device/gemini330/G330Device.cpp
@@ -32,7 +32,6 @@
 #include "property/FilterPropertyAccessors.hpp"
 #include "property/PrivateFilterPropertyAccessors.hpp"
 #include "monitor/DeviceMonitor.hpp"
-#include "monitor/DeviceActivityRecorder.hpp"
 #include "syncconfig/DeviceSyncConfigurator.hpp"
 #include "firmwareupdater/FirmwareUpdater.hpp"
 #include "firmwareupdater/firmwareupdateguard/FirmwareUpdateGuards.hpp"
@@ -1534,15 +1533,6 @@ void G330NetDevice::init() {
         TRY_EXECUTE({ factory = std::make_shared<FirmwareUpdateGuardFactory>(this); })
         return factory;
     });
-
-    registerComponent(
-        OB_DEV_COMPONENT_DEVICE_ACTIVITY_RECORDER,
-        [this]() {
-            std::shared_ptr<DeviceActivityRecorder> activityRecorder;
-            TRY_EXECUTE({ activityRecorder = std::make_shared<DeviceActivityRecorder>(this); })
-            return activityRecorder;
-        },
-        false);
 
     auto propertyServer = getPropertyServer();
     auto fwVersion      = getFirmwareVersionInt();

--- a/src/device/lidar/LiDARDevice.cpp
+++ b/src/device/lidar/LiDARDevice.cpp
@@ -42,15 +42,6 @@ void LiDARDevice::init() {
 
     fetchDeviceInfo();
 
-    registerComponent(
-        OB_DEV_COMPONENT_DEVICE_ACTIVITY_RECORDER,
-        [this]() {
-            std::shared_ptr<DeviceActivityRecorder> activityRecorder;
-            TRY_EXECUTE({ activityRecorder = std::make_shared<DeviceActivityRecorder>(this); })
-            return activityRecorder;
-        },
-        false);
-
     auto algParamManager = std::make_shared<LiDARAlgParamManager>(this);
     registerComponent(OB_DEV_COMPONENT_ALG_PARAM_MANAGER, algParamManager);
 }

--- a/src/device/lidar/MS600Device.cpp
+++ b/src/device/lidar/MS600Device.cpp
@@ -35,15 +35,6 @@ void MS600Device::init() {
     initSensorList();
 
     fetchDeviceInfo();
-
-    registerComponent(
-    OB_DEV_COMPONENT_DEVICE_ACTIVITY_RECORDER,
-    [this]() {
-        std::shared_ptr<DeviceActivityRecorder> activityRecorder;
-        TRY_EXECUTE({ activityRecorder = std::make_shared<DeviceActivityRecorder>(this); })
-        return activityRecorder;
-    },
-    false);
 }
 
 void MS600Device::fetchDeviceInfo() {


### PR DESCRIPTION
Some net devices previously had this component registered, but not all. This meant that the device I am using, Femto Mega, wasn't able to do the recovery step that uses `checkDeviceActivity` to figure out if it's still online.

In my logs I would see something like this:
```
[05/19 23:18:16.198626][warning][994036][NetDeviceEnumerator.cpp:277] 1 net device removed:
[05/19 23:18:16.198642][warning][994036][NetDeviceEnumerator.cpp:278] - Name: Femto Mega, PID: 0x0669, ...
...
[05/19 23:18:16.388417][warning][994062][ObException.cpp:25] A recoverable_exception has occurred!
 - where: DeviceBase.cpp(330)
 - msg: Device is deactivated/disconnected! DeviceComponentId:0
 - type: WRONG_API_CALL_SEQUENCE
 - status: 108
[05/19 23:18:16.440090][warning][994062][ObException.cpp:25] A recoverable_exception has occurred!
 - where: DeviceBase.cpp(330)
 - msg: Device is deactivated/disconnected! DeviceComponentId:0
 - type: WRONG_API_CALL_SEQUENCE
 - status: 108
...
```

This change registers `DeviceActivityRecorder` on all devices that list their connection type as "Ethernet", and removes the now unnecessary registrations in G330, LiDAR, and MS600.