### PR TITLE
Add optional GMSL metadata trace for timestamp drop diagnosis

### DIFF
--- a/src/device/gemini330/G330MetadataModifier.cpp
+++ b/src/device/gemini330/G330MetadataModifier.cpp
@@ -3,8 +3,95 @@
 
 #include "G330MetadataModifier.hpp"
 #include "frame/Frame.hpp"
+#include "logger/Logger.hpp"
+
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <string>
 
 namespace libobsensor {
+
+namespace {
+constexpr size_t kGmslMetadataTraceFrameCounterOffset = 12;
+constexpr size_t kGmslMetadataTraceSofSecOffset       = 24;
+constexpr size_t kGmslMetadataTraceSofNsecOffset      = 28;
+constexpr size_t kGmslMetadataTraceExposureOffset     = 32;
+constexpr size_t kGmslMetadataTraceBitmapOffset       = 64;
+constexpr size_t kGmslMetadataTraceOffsetUsecOffset   = 68;
+
+uint32_t readLe32GmslMetadataTrace(const uint8_t *data, size_t size, size_t offset) {
+    if(!data || offset + 4 > size) {
+        return 0;
+    }
+    auto ptr = data + offset;
+    return static_cast<uint32_t>(ptr[0]) | (static_cast<uint32_t>(ptr[1]) << 8) | (static_cast<uint32_t>(ptr[2]) << 16)
+           | (static_cast<uint32_t>(ptr[3]) << 24);
+}
+
+struct GmslMetadataTraceModifierState {
+    bool     hasLastFrameCounter = false;
+    uint32_t lastFrameCounter    = 0;
+    uint64_t lastSdkNumber       = 0;
+    uint32_t sampleCount         = 0;
+};
+
+std::mutex                                      gmslMetadataTraceModifierMutex;
+std::map<OBFrameType, GmslMetadataTraceModifierState> gmslMetadataTraceModifierStates;
+
+bool isGmslMetadataTraceEnabled() {
+    static const bool enabled = [] {
+        const char *value = std::getenv("OB_GMSL_METADATA_TRACE");
+        if(!value) {
+            return false;
+        }
+        return std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 || std::strcmp(value, "TRUE") == 0 || std::strcmp(value, "on") == 0
+               || std::strcmp(value, "ON") == 0;
+    }();
+    return enabled;
+}
+
+void logGmslMetadataTraceModifier(const std::shared_ptr<Frame> &frame, const uint8_t *metadataBuffer, size_t metadataSize) {
+    if(!isGmslMetadataTraceEnabled()) {
+        return;
+    }
+
+    const uint32_t frameCounter = readLe32GmslMetadataTrace(metadataBuffer, metadataSize, kGmslMetadataTraceFrameCounterOffset);
+    const uint32_t sofSec       = readLe32GmslMetadataTrace(metadataBuffer, metadataSize, kGmslMetadataTraceSofSecOffset);
+    const uint32_t sofNsec      = readLe32GmslMetadataTrace(metadataBuffer, metadataSize, kGmslMetadataTraceSofNsecOffset);
+    const uint32_t exposure     = readLe32GmslMetadataTrace(metadataBuffer, metadataSize, kGmslMetadataTraceExposureOffset);
+    const uint32_t bitmap       = readLe32GmslMetadataTrace(metadataBuffer, metadataSize, kGmslMetadataTraceBitmapOffset);
+    const uint32_t offsetUsec   = readLe32GmslMetadataTrace(metadataBuffer, metadataSize, kGmslMetadataTraceOffsetUsecOffset);
+
+    std::lock_guard<std::mutex> lock(gmslMetadataTraceModifierMutex);
+    auto                       &state = gmslMetadataTraceModifierStates[frame->getType()];
+    const bool repeated = state.hasLastFrameCounter && frameCounter == state.lastFrameCounter;
+    const bool jumped   = state.hasLastFrameCounter && frameCounter > state.lastFrameCounter + 1;
+    const bool shouldLog = state.sampleCount < 12 || repeated || jumped;
+
+    if(shouldLog) {
+        std::string flags;
+        if(repeated) {
+            flags += " frame_counter_repeat";
+        }
+        if(jumped) {
+            flags += " frame_counter_jump";
+        }
+        LOG_INFO("GMSL metadata trace source=modifier frameType={} sdkNumber={} dSdkNumber={} mdFrameCounter={} dMdFrameCounter={} sofSec={} sofNsec={} "
+                 "exposure={} bitmap=0x{:x} offsetUsec={} flags={}",
+                 static_cast<int>(frame->getType()), frame->getNumber(),
+                 state.sampleCount > 0 ? static_cast<int64_t>(frame->getNumber()) - static_cast<int64_t>(state.lastSdkNumber) : 0, frameCounter,
+                 state.hasLastFrameCounter ? static_cast<int64_t>(frameCounter) - static_cast<int64_t>(state.lastFrameCounter) : 0, sofSec, sofNsec,
+                 exposure, bitmap, offsetUsec, flags.empty() ? "none" : flags.c_str());
+    }
+
+    state.hasLastFrameCounter = true;
+    state.lastFrameCounter    = frameCounter;
+    state.lastSdkNumber       = frame->getNumber();
+    state.sampleCount++;
+}
+}  // namespace
 
 G330GMSLMetadataModifier::G330GMSLMetadataModifier(IDevice *owner) : DeviceComponentBase(owner) {}
 G330GMSLMetadataModifier::~G330GMSLMetadataModifier() {}
@@ -22,6 +109,7 @@ void G330GMSLMetadataModifier::modify(std::shared_ptr<Frame> frame) {
         for(int i = 0; i < metadataSize; i++) {
             metadataBuffer[i + 12] = static_cast<uint8_t>(frameDataBuffer[i] >> 8);
         }
+        logGmslMetadataTraceModifier(frame, metadataBuffer, metadataSize + 12);
     } break;
     case OB_FRAME_DEPTH: {
         // Copy metadata from the frame data and clear the metadata area
@@ -33,6 +121,7 @@ void G330GMSLMetadataModifier::modify(std::shared_ptr<Frame> frame) {
         // Zeroing the metadata region prevents horizontal stripes in display
         // For depth images, zeroed pixels are interpreted as depth=0 and do not affect usage
         memset(frameData, 0, metadataSize * sizeof(uint16_t));
+        logGmslMetadataTraceModifier(frame, metadataBuffer, metadataSize + 12);
     } break;
     case OB_FRAME_IR:
     case OB_FRAME_IR_LEFT:
@@ -42,6 +131,7 @@ void G330GMSLMetadataModifier::modify(std::shared_ptr<Frame> frame) {
         memcpy(metadataBuffer + 12, frameData, metadataSize);
         // Zeroing the metadata region prevents horizontal stripes in display
         memset(frameData, 0, metadataSize);
+        logGmslMetadataTraceModifier(frame, metadataBuffer, metadataSize + 12);
     } break;
     default:
         // do nothing

--- a/src/platform/usb/uvc/ObV4lGmslDevicePort.cpp
+++ b/src/platform/usb/uvc/ObV4lGmslDevicePort.cpp
@@ -10,7 +10,13 @@
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 
+#include <algorithm>
+#include <array>
+#include <cstdlib>
+#include <cstring>
 #include <list>
+#include <map>
+#include <mutex>
 #include <regex>
 
 #include <linux/media.h>
@@ -44,6 +50,177 @@ namespace libobsensor {
 
 #define USE_MEMORY_MMAP true
 std::mutex mMultiThreadI2CMutex;
+
+namespace {
+constexpr size_t kGmslMetadataTraceMetadataSnapshotBytes = 96;
+constexpr size_t kGmslMetadataTraceImageFrameCounterOffset = 0;
+constexpr size_t kGmslMetadataTraceImageSofSecOffset       = 12;
+constexpr size_t kGmslMetadataTraceImageSofNsecOffset      = 16;
+constexpr size_t kGmslMetadataTraceImageOffsetUsecOffset   = 56;
+
+uint32_t readLe32GmslMetadataTrace(const void *data, size_t size, size_t offset) {
+    if(!data || offset + 4 > size) {
+        return 0;
+    }
+    auto ptr = static_cast<const uint8_t *>(data) + offset;
+    return static_cast<uint32_t>(ptr[0]) | (static_cast<uint32_t>(ptr[1]) << 8) | (static_cast<uint32_t>(ptr[2]) << 16)
+           | (static_cast<uint32_t>(ptr[3]) << 24);
+}
+
+struct GmslMetadataTraceV4LState {
+    bool     hasLastVideoSeq  = false;
+    bool     hasLastMetaSeq   = false;
+    bool     hasLastImageCounter = false;
+    uint32_t lastVideoSeq     = 0;
+    uint32_t lastMetaSeq      = 0;
+    uint32_t lastImageCounter = 0;
+    int64_t  lastImageSofUsec = 0;
+    uint64_t lastLoopIndex    = 0;
+    uint32_t sampleCount      = 0;
+};
+
+struct GmslMetadataTraceMetadataSnapshot {
+    bool                                               valid     = false;
+    uint32_t                                           index     = 0;
+    uint32_t                                           sequence  = 0;
+    uint32_t                                           bytesused = 0;
+    uint32_t                                           copied    = 0;
+    std::array<uint8_t, kGmslMetadataTraceMetadataSnapshotBytes> bytes     = {};
+};
+
+std::mutex                                      gmslMetadataTraceV4LMutex;
+std::map<std::string, GmslMetadataTraceV4LState> gmslMetadataTraceV4LStates;
+
+bool isGmslMetadataTraceEnabled() {
+    static const bool enabled = [] {
+        const char *value = std::getenv("OB_GMSL_METADATA_TRACE");
+        if(!value) {
+            return false;
+        }
+        return std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 || std::strcmp(value, "TRUE") == 0 || std::strcmp(value, "on") == 0
+               || std::strcmp(value, "ON") == 0;
+    }();
+    return enabled;
+}
+
+uint8_t readG330PrependedByteGmslMetadataTrace(const void *data, size_t size, int streamType, size_t metadataOffset) {
+    if(!data) {
+        return 0;
+    }
+    auto ptr = static_cast<const uint8_t *>(data);
+    if(streamType == OB_STREAM_COLOR || streamType == OB_STREAM_COLOR_LEFT || streamType == OB_STREAM_COLOR_RIGHT) {
+        const size_t srcOffset = metadataOffset * 2 + 1;
+        return srcOffset < size ? ptr[srcOffset] : 0;
+    }
+    if(streamType == OB_STREAM_DEPTH) {
+        const size_t srcOffset = metadataOffset * 2;
+        return srcOffset < size ? ptr[srcOffset] : 0;
+    }
+    return metadataOffset < size ? ptr[metadataOffset] : 0;
+}
+
+uint32_t readG330PrependedLe32GmslMetadataTrace(const void *data, size_t size, int streamType, size_t metadataOffset) {
+    return static_cast<uint32_t>(readG330PrependedByteGmslMetadataTrace(data, size, streamType, metadataOffset))
+           | (static_cast<uint32_t>(readG330PrependedByteGmslMetadataTrace(data, size, streamType, metadataOffset + 1)) << 8)
+           | (static_cast<uint32_t>(readG330PrependedByteGmslMetadataTrace(data, size, streamType, metadataOffset + 2)) << 16)
+           | (static_cast<uint32_t>(readG330PrependedByteGmslMetadataTrace(data, size, streamType, metadataOffset + 3)) << 24);
+}
+
+std::string hexPrefixGmslMetadataTrace(const void *data, size_t size, size_t maxBytes) {
+    if(!data || size == 0 || maxBytes == 0) {
+        return "";
+    }
+    static constexpr char kHex[] = "0123456789abcdef";
+    auto                  ptr    = static_cast<const uint8_t *>(data);
+    const size_t          count  = std::min(size, maxBytes);
+    std::string           out;
+    out.reserve(count * 3);
+    for(size_t i = 0; i < count; ++i) {
+        if(i > 0) {
+            out.push_back(':');
+        }
+        out.push_back(kHex[(ptr[i] >> 4) & 0x0f]);
+        out.push_back(kHex[ptr[i] & 0x0f]);
+    }
+    return out;
+}
+
+void logGmslMetadataTraceV4L(const std::string &devName, int streamType, uint64_t loopIndex, uint32_t videoSeq, uint32_t videoBytes, uint32_t videoIndex,
+                             int metadataIndex, uint32_t metaSeq, uint32_t metaLen, uint32_t metaFirstU32, uint32_t payloadDwPresentationTime,
+                             const void *metadataPtr, size_t metadataSize, const GmslMetadataTraceMetadataSnapshot *dqbufSnapshot,
+                             bool dqbufLaterHexEqual, uint32_t imageFrameCounter, uint32_t imageSofSec, uint32_t imageSofNsec, uint32_t imageOffsetUsec) {
+    if(!isGmslMetadataTraceEnabled()) {
+        return;
+    }
+
+    std::lock_guard<std::mutex> lock(gmslMetadataTraceV4LMutex);
+    auto                       &state = gmslMetadataTraceV4LStates[devName + ":" + std::to_string(streamType)];
+    const bool videoSeqJump = state.hasLastVideoSeq && videoSeq != state.lastVideoSeq + 1;
+    const bool metaSeqJump  = metadataIndex >= 0 && state.hasLastMetaSeq && metaSeq != state.lastMetaSeq + 1;
+    const bool loopJump     = state.sampleCount > 0 && loopIndex != state.lastLoopIndex + 1;
+    const int64_t imageSofUsec = static_cast<int64_t>(imageSofSec) * 1000000 + static_cast<int64_t>(imageSofNsec) / 1000
+                                 - static_cast<int64_t>(imageOffsetUsec);
+    const bool imageCounterRepeat = state.hasLastImageCounter && imageFrameCounter == state.lastImageCounter;
+    const bool imageCounterJump   = state.hasLastImageCounter && imageFrameCounter > state.lastImageCounter + 1;
+    const bool hasDqbufSnapshot   = dqbufSnapshot && dqbufSnapshot->valid;
+    const bool dqbufLaterHexDiff  = hasDqbufSnapshot && metadataPtr && !dqbufLaterHexEqual;
+    const bool shouldLog          = state.sampleCount < 12 || videoSeqJump || metaSeqJump || loopJump || imageCounterRepeat || imageCounterJump
+                           || dqbufLaterHexDiff;
+
+    if(shouldLog) {
+        std::string flags;
+        if(videoSeqJump) {
+            flags += " video_seq_jump";
+        }
+        if(metaSeqJump) {
+            flags += " meta_seq_jump";
+        }
+        if(loopJump) {
+            flags += " loop_jump";
+        }
+        if(imageCounterRepeat) {
+            flags += " image_counter_repeat";
+        }
+        if(imageCounterJump) {
+            flags += " image_counter_jump";
+        }
+        if(dqbufLaterHexDiff) {
+            flags += " dqbuf_later_hex_diff";
+        }
+        const auto metaHex       = hexPrefixGmslMetadataTrace(metadataPtr, metadataSize, 64);
+        const auto dqbufMetaHex  = hasDqbufSnapshot ? hexPrefixGmslMetadataTrace(dqbufSnapshot->bytes.data(), dqbufSnapshot->copied,
+                                                                                 kGmslMetadataTraceMetadataSnapshotBytes)
+                                                    : "";
+        const auto laterMetaHex  = hexPrefixGmslMetadataTrace(metadataPtr, metadataSize, kGmslMetadataTraceMetadataSnapshotBytes);
+        const auto dVideoSeq     = state.hasLastVideoSeq ? static_cast<int64_t>(videoSeq) - static_cast<int64_t>(state.lastVideoSeq) : 0;
+        const auto dMetaSeq      = state.hasLastMetaSeq ? static_cast<int64_t>(metaSeq) - static_cast<int64_t>(state.lastMetaSeq) : 0;
+        const auto dImageCounter = state.hasLastImageCounter ? static_cast<int64_t>(imageFrameCounter) - static_cast<int64_t>(state.lastImageCounter) : 0;
+        const auto dImageSofMs   = state.hasLastImageCounter ? (imageSofUsec - state.lastImageSofUsec) / 1000.0 : 0.0;
+
+        LOG_INFO("GMSL metadata trace source=v4l dev={} streamType={} loopIndex={} videoSeq={} dVideoSeq={} videoBufIndex={} videoBytes={} "
+                 "metadataIndex={} metaSeq={} dMetaSeq={} metaLen={} metaFirstU32={} payloadDwPresentationTime={} metaHex={} dqbufMetaSeq={} "
+                 "dqbufMetaLen={} dqbufMetaCopied={} dqbufMetaHex={} laterMetaHex={} dqbufLaterHexEqual={} imgFrameCounter={} dImgFrameCounter={} "
+                 "imgSofSec={} imgSofNsec={} imgOffsetUsec={} imgSofUsec={} dImgSofMs={} flags={}",
+                 devName, streamType, loopIndex, videoSeq, dVideoSeq, videoIndex, videoBytes, metadataIndex, metaSeq, dMetaSeq, metaLen, metaFirstU32,
+                 payloadDwPresentationTime, metaHex, hasDqbufSnapshot ? dqbufSnapshot->sequence : 0, hasDqbufSnapshot ? dqbufSnapshot->bytesused : 0,
+                 hasDqbufSnapshot ? dqbufSnapshot->copied : 0, dqbufMetaHex, laterMetaHex, hasDqbufSnapshot ? (dqbufLaterHexEqual ? 1 : 0) : -1,
+                 imageFrameCounter, dImageCounter, imageSofSec, imageSofNsec, imageOffsetUsec, imageSofUsec, dImageSofMs,
+                 flags.empty() ? "none" : flags.c_str());
+    }
+
+    state.hasLastVideoSeq = true;
+    state.lastVideoSeq    = videoSeq;
+    if(metadataIndex >= 0) {
+        state.hasLastMetaSeq = true;
+        state.lastMetaSeq    = metaSeq;
+    }
+    state.hasLastImageCounter = true;
+    state.lastImageCounter    = imageFrameCounter;
+    state.lastImageSofUsec    = imageSofUsec;
+    state.lastLoopIndex       = loopIndex;
+    state.sampleCount++;
+}
+}  // namespace
 
 static std::map<uint32_t, uint32_t> v4lFourccMapGmsl = {
     { 0x47524559, 0x59382020 }, /*'GREY' to 'Y8  '*/
@@ -630,6 +807,8 @@ void writeBufferToFile(const char *buf, std::size_t size, const std::string &fil
 void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHandle) {
     int metadataBufferIndex = -1;
     int colorFrameNum       = 0;  // color drop 1~3 frame -> fix color green screen issue.
+    std::array<GmslMetadataTraceMetadataSnapshot, MAX_BUFFER_COUNT_GMSL> metadataSnapshots = {};
+    const bool metadataTraceEnabled = isGmslMetadataTraceEnabled();
 
     devHandle->loopFrameIndex.store(1);  // frame number start from 1
     try {
@@ -714,6 +893,20 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
                     devHandle->metadataBuffers[buf.index].actual_length = buf.bytesused;
                     devHandle->metadataBuffers[buf.index].sequence      = buf.sequence;
                     metadataBufferIndex                                 = buf.index;
+                    if(metadataTraceEnabled && buf.index < devHandle->metadataBuffers.size() && devHandle->metadataBuffers[buf.index].ptr) {
+                        auto &snapshot  = metadataSnapshots[buf.index];
+                        auto &metaBuf   = devHandle->metadataBuffers[buf.index];
+                        snapshot.valid  = true;
+                        snapshot.index  = buf.index;
+                        snapshot.sequence  = buf.sequence;
+                        snapshot.bytesused = buf.bytesused;
+                        snapshot.copied    = static_cast<uint32_t>(std::min<size_t>({ static_cast<size_t>(buf.bytesused),
+                                                                                       static_cast<size_t>(metaBuf.length),
+                                                                                       kGmslMetadataTraceMetadataSnapshotBytes }));
+                        if(snapshot.copied > 0) {
+                            std::memcpy(snapshot.bytes.data(), metaBuf.ptr, snapshot.copied);
+                        }
+                    }
                 }
 
                 if(devHandle->isCapturing) {
@@ -740,6 +933,33 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
                     TRY_EXECUTE({
                         auto rawframe   = FrameFactory::createFrameFromStreamProfile(devHandle->profile);
                         auto videoFrame = rawframe->as<VideoFrame>();
+                        uint32_t metadataTraceMetaSeq                  = 0;
+                        uint32_t metadataTraceMetaLen                  = 0;
+                        uint32_t metadataTraceMetaFirstU32             = 0;
+                        uint32_t metadataTracePayloadDwPresentationTime = 0;
+                        int      metadataTraceMetadataIndex            = metadataBufferIndex;
+                        const void *metadataTraceMetadataPtr           = nullptr;
+                        const GmslMetadataTraceMetadataSnapshot *metadataTraceDqbufSnapshot = nullptr;
+                        bool     metadataTraceDqbufLaterHexEqual       = false;
+                        const int metadataTraceStreamType              = static_cast<int>(devHandle->profile->getType());
+                        uint32_t  metadataTraceImageFrameCounter       = 0;
+                        uint32_t  metadataTraceImageSofSec             = 0;
+                        uint32_t  metadataTraceImageSofNsec            = 0;
+                        uint32_t  metadataTraceImageOffsetUsec         = 0;
+                        if(metadataTraceEnabled) {
+                            const auto metadataTraceVideoData     = devHandle->buffers[buf.index].ptr;
+                            metadataTraceImageFrameCounter = readG330PrependedLe32GmslMetadataTrace(
+                                metadataTraceVideoData, buf.bytesused, metadataTraceStreamType, kGmslMetadataTraceImageFrameCounterOffset);
+                            metadataTraceImageSofSec = readG330PrependedLe32GmslMetadataTrace(metadataTraceVideoData, buf.bytesused,
+                                                                                              metadataTraceStreamType,
+                                                                                              kGmslMetadataTraceImageSofSecOffset);
+                            metadataTraceImageSofNsec = readG330PrependedLe32GmslMetadataTrace(metadataTraceVideoData, buf.bytesused,
+                                                                                               metadataTraceStreamType,
+                                                                                               kGmslMetadataTraceImageSofNsecOffset);
+                            metadataTraceImageOffsetUsec = readG330PrependedLe32GmslMetadataTrace(metadataTraceVideoData, buf.bytesused,
+                                                                                                  metadataTraceStreamType,
+                                                                                                  kGmslMetadataTraceImageOffsetUsecOffset);
+                        }
                         // if((DetectPlatform() == Platform::Xavier) || (DetectPlatform() == Platform::Orin))
                         if(1 > 0)  // Modify the default setting to apply special resolution processing to all NVIDIA platforms
                         {
@@ -754,12 +974,32 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
                             auto &metaBuf                = devHandle->metadataBuffers[metadataBufferIndex];
                             auto  uvc_payload_header     = metaBuf.ptr;
                             auto  uvc_payload_header_len = metaBuf.actual_length;
+                            if(metadataTraceEnabled) {
+                                metadataTraceMetaSeq        = metaBuf.sequence;
+                                metadataTraceMetaLen        = uvc_payload_header_len;
+                                metadataTraceMetaFirstU32   = readLe32GmslMetadataTrace(uvc_payload_header, uvc_payload_header_len, 0);
+                                metadataTraceMetadataPtr    = uvc_payload_header;
+                                metadataTraceDqbufSnapshot  = metadataBufferIndex < static_cast<int>(metadataSnapshots.size())
+                                                            && metadataSnapshots[metadataBufferIndex].valid
+                                                        ? &metadataSnapshots[metadataBufferIndex]
+                                                        : nullptr;
+                            }
+                            if(metadataTraceEnabled && metadataTraceDqbufSnapshot) {
+                                const size_t compareLen = std::min<size_t>(
+                                    { static_cast<size_t>(metadataTraceDqbufSnapshot->copied), static_cast<size_t>(uvc_payload_header_len),
+                                      kGmslMetadataTraceMetadataSnapshotBytes });
+                                metadataTraceDqbufLaterHexEqual = compareLen == metadataTraceDqbufSnapshot->copied && compareLen > 0
+                                                            && std::memcmp(metadataTraceDqbufSnapshot->bytes.data(), uvc_payload_header, compareLen) == 0;
+                            }
                             videoFrame->updateMetadata(static_cast<const uint8_t *>(uvc_payload_header), 12);
                             videoFrame->appendMetadata(static_cast<const uint8_t *>(uvc_payload_header), uvc_payload_header_len);
 
                             if(uvc_payload_header_len >= sizeof(StandardUvcFramePayloadHeader)) {
                                 auto payloadHeader = (StandardUvcFramePayloadHeader *)uvc_payload_header;
                                 videoFrame->setTimeStampUsec(payloadHeader->dwPresentationTime);
+                                if(metadataTraceEnabled) {
+                                    metadataTracePayloadDwPresentationTime = payloadHeader->dwPresentationTime;
+                                }
                             }
                         }
 
@@ -772,6 +1012,14 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
 
                         // fix frame index zero issue.
                         videoFrame->setNumber(devHandle->loopFrameIndex);
+                        if(metadataTraceEnabled) {
+                            logGmslMetadataTraceV4L(devHandle->info->name, metadataTraceStreamType, devHandle->loopFrameIndex.load(), buf.sequence,
+                                                    buf.bytesused, buf.index, metadataTraceMetadataIndex, metadataTraceMetaSeq, metadataTraceMetaLen,
+                                                    metadataTraceMetaFirstU32, metadataTracePayloadDwPresentationTime, metadataTraceMetadataPtr,
+                                                    metadataTraceMetaLen, metadataTraceDqbufSnapshot, metadataTraceDqbufLaterHexEqual,
+                                                    metadataTraceImageFrameCounter, metadataTraceImageSofSec, metadataTraceImageSofNsec,
+                                                    metadataTraceImageOffsetUsec);
+                        }
                         // LOG_DEBUG("set loopFrameIndex:{}", devHandle->loopFrameIndex);
 
                         if(devHandle->profile->getType() == OB_STREAM_COLOR) {


### PR DESCRIPTION
## Summary

This PR adds a default-off GMSL metadata diagnostic trace for Gemini 330 / V4L GMSL capture paths.

It is a diagnostic change, not a behavior change or final timestamp fix. Normal SDK capture behavior is unchanged unless `OB_GMSL_METADATA_TRACE=1` is explicitly enabled.

## Background

During field debugging on Jetson AGX Orin with a GMSL hardware-triggered 30 FPS input, we observed average 30 FPS delivery, but intermittent application-visible device timestamp / frame interval gaps. System timestamps were stable, while device metadata-derived timestamps could jump by integer multiples of the normal frame period.

Using system/global timestamps can reduce the visible application timestamp jump, but it does not identify the root cause because SDK-side frame aggregation and downstream frame metadata still depend on the device metadata path.

This trace is intended to help Orbbec SDK and driver engineers separate these cases:

- SDK frame binding or metadata association reads the wrong metadata for a video frame.
- SDK V4L metadata buffer lifetime / requeue timing causes a later mmap read to see overwritten data.
- Platform driver / firmware / V4L metadata side-channel already generates repeated or stale metadata.
- NVIDIA GMSL side-channel metadata parsing differs from embedded/prepended metadata carried in the image payload.

## What this adds

When `OB_GMSL_METADATA_TRACE=1` is set, the SDK emits gated `LOG_INFO` records from two boundaries. `LOG_INFO` is used because the trace is already opt-in and needs to be visible in standard SDK log files collected by FAE / field engineers without changing SDK logger level.

1. V4L GMSL capture path
   - metadata `VIDIOC_DQBUF` immediate 96-byte snapshot
   - later mmap pointer read for the metadata bound to the video frame
   - metadata buffer index, metadata sequence, video sequence, bytes used
   - `dwPresentationTime` and metadata hex prefixes
   - embedded/prepended G330 image metadata fields: frame counter, SOF seconds/nanoseconds, offset usec
   - anomaly flags such as `video_seq_jump`, `meta_seq_jump`, `image_counter_repeat`, `image_counter_jump`, `dqbuf_later_hex_diff`

2. G330 metadata modifier path
   - SDK frame number
   - parsed metadata frame counter
   - SOF seconds/nanoseconds
   - exposure / bitmap / offset usec
   - anomaly flags such as `frame_counter_repeat` and `frame_counter_jump`

The trace logs only early samples and anomaly cases. It does not continuously dump every frame during normal operation.

## How this helps isolate the issue

The key comparison is:

- If the DQBUF-time metadata snapshot increments normally, but the later mmap pointer read repeats or differs, the likely issue is SDK-side metadata buffer lifetime, requeue timing, or frame/metadata binding.
- If the DQBUF-time metadata snapshot already repeats or jumps, the issue is likely below SDK frame aggregation, in the platform driver / firmware / V4L metadata generation path.
- If V4L side-channel metadata is unstable but embedded/prepended image metadata remains stable, the issue is likely specific to the platform side-channel metadata path.
- If both side-channel and embedded metadata carry the same repeated counter/timestamp, the issue is likely before SDK parsing, closer to firmware / sensor / GMSL metadata generation.

This gives SDK and driver engineers a shared log format to decide which layer should be investigated next.

## Usage

Run the target application with:

```bash
OB_GMSL_METADATA_TRACE=1 ./your_orbbec_app
```

Search the SDK log for:

```text
GMSL metadata trace source=v4l
GMSL metadata trace source=modifier
```

## Jetson AGX Orin validation

Validation was run on a Jetson AGX Orin GMSL setup:

- OS/kernel: Ubuntu 22.04, Linux `5.15.148-tegra` aarch64
- Compiler: g++ 11.4.0
- CMake: 3.22.1
- SDK test binary: existing release-package `ob_quick_start`, loaded with the PR-built `libOrbbecSDK.so.2`

Build commands:

```bash
cmake -S . -B build_pr173 -DCMAKE_BUILD_TYPE=Release \
  -DOB_BUILD_EXAMPLES=OFF -DOB_BUILD_TESTS=OFF -DOB_BUILD_DOCS=OFF -DOB_BUILD_TOOLS=OFF
cmake --build build_pr173 --target OrbbecSDK -j$(nproc)
```

Result: configure and build exited 0. The incremental rebuild compiled both changed translation units and linked `libOrbbecSDK.so`:

- `src/platform/usb/uvc/ObV4lGmslDevicePort.cpp`
- `src/device/gemini330/G330MetadataModifier.cpp`

Default-off runtime check:

```bash
timeout 25 env LD_LIBRARY_PATH="$PR_LIB:$SDK_RELEASE/lib:$LD_LIBRARY_PATH" ./ob_quick_start
```

Result:

- `RUN_DEFAULT_OFF_EXIT=124` because the process was intentionally stopped by `timeout` after 25 seconds.
- `TRACE_LINE_COUNT=0`.
- The original interval anomaly was still reproduced, for example Color / Depth intervals of `66.746 ms` and `100.119 ms`.

Trace-on runtime check:

```bash
timeout 25 env OB_GMSL_METADATA_TRACE=1 \
  LD_LIBRARY_PATH="$PR_LIB:$SDK_RELEASE/lib:$LD_LIBRARY_PATH" ./ob_quick_start
```

Result:

- `RUN_TRACE_ON_INFO_EXIT=124` because the process was intentionally stopped by `timeout` after 25 seconds.
- `TRACE_LINE_COUNT=519`.
- Trace source counts: `260 source=v4l`, `259 source=modifier`.
- The log exposed both normal 33 ms frame-counter increments and anomaly cases such as `frame_counter_jump` / `image_counter_jump`.

Example excerpt from the embedded-metadata driver run:

```text
GMSL metadata trace source=v4l dev=/dev/video1 streamType=2 loopIndex=10 videoSeq=9 dVideoSeq=1 videoBufIndex=1 videoBytes=614400 metadataIndex=-1 metaSeq=0 dMetaSeq=0 metaLen=0 ... imgFrameCounter=3 dImgFrameCounter=-7 imgSofSec=453 imgSofNsec=830077858 imgOffsetUsec=1130 imgSofUsec=453828947 dImgSofMs=-367.103 flags=none
GMSL metadata trace source=v4l dev=/dev/video1 streamType=2 loopIndex=11 videoSeq=10 dVideoSeq=1 videoBufIndex=2 videoBytes=614400 metadataIndex=-1 metaSeq=0 dMetaSeq=0 metaLen=0 ... imgFrameCounter=12 dImgFrameCounter=9 imgSofSec=454 imgSofNsec=263926983 imgOffsetUsec=1130 imgSofUsec=454262796 dImgSofMs=433.849 flags= image_counter_jump
GMSL metadata trace source=modifier frameType=2 sdkNumber=11 dSdkNumber=1 mdFrameCounter=12 dMdFrameCounter=9 sofSec=454 sofNsec=263926983 exposure=200 bitmap=0x602 offsetUsec=1130 flags= frame_counter_jump
```

In this embedded-metadata mode, `metadataIndex=-1` / `metaLen=0` is expected because the V4L side-channel metadata queue is not used; the trace still records parsed image metadata at both the V4L boundary and the metadata modifier boundary. That is useful for checking whether the parsed embedded metadata is already jumping before SDK aggregation or whether the jump appears later in SDK frame processing.

## Local static checks

- No leftover ad-hoc `TS_SRC_*` or `TsProbe` trace strings.
- No `std::cout` / `std::cerr` field-debug trace output was added.
- New trace output is gated by `OB_GMSL_METADATA_TRACE`.
- `git diff --check` passes.

## Notes

This PR intentionally does not change timestamp policy, frame aggregation, metadata parsing semantics, or capture timing. It only adds a diagnostic boundary trace so that SDK-side and platform/driver-side causes can be distinguished with evidence.