### PR TITLE
Add default-off GMSL metadata tracing for timestamp diagnosis

### DIFF
--- a/src/device/gemini330/G330MetadataModifier.cpp
+++ b/src/device/gemini330/G330MetadataModifier.cpp
@@ -3,6 +3,9 @@
 
 #include "G330MetadataModifier.hpp"
 #include "frame/Frame.hpp"
+#include "utils/GmslMetadataTrace.hpp"
+
+#include <cstring>
 
 namespace libobsensor {
 
@@ -22,6 +25,7 @@ void G330GMSLMetadataModifier::modify(std::shared_ptr<Frame> frame) {
         for(int i = 0; i < metadataSize; i++) {
             metadataBuffer[i + 12] = static_cast<uint8_t>(frameDataBuffer[i] >> 8);
         }
+        utils::GmslMetadataTrace::logG330ModifierFrame(frame->getType(), frame->getNumber(), metadataBuffer, metadataSize + 12);
     } break;
     case OB_FRAME_DEPTH: {
         // Copy metadata from the frame data and clear the metadata area
@@ -33,6 +37,7 @@ void G330GMSLMetadataModifier::modify(std::shared_ptr<Frame> frame) {
         // Zeroing the metadata region prevents horizontal stripes in display
         // For depth images, zeroed pixels are interpreted as depth=0 and do not affect usage
         memset(frameData, 0, metadataSize * sizeof(uint16_t));
+        utils::GmslMetadataTrace::logG330ModifierFrame(frame->getType(), frame->getNumber(), metadataBuffer, metadataSize + 12);
     } break;
     case OB_FRAME_IR:
     case OB_FRAME_IR_LEFT:
@@ -42,6 +47,7 @@ void G330GMSLMetadataModifier::modify(std::shared_ptr<Frame> frame) {
         memcpy(metadataBuffer + 12, frameData, metadataSize);
         // Zeroing the metadata region prevents horizontal stripes in display
         memset(frameData, 0, metadataSize);
+        utils::GmslMetadataTrace::logG330ModifierFrame(frame->getType(), frame->getNumber(), metadataBuffer, metadataSize + 12);
     } break;
     default:
         // do nothing

--- a/src/platform/usb/uvc/ObV4lGmslDevicePort.cpp
+++ b/src/platform/usb/uvc/ObV4lGmslDevicePort.cpp
@@ -10,7 +10,11 @@
 #include <sys/stat.h>
 #include <sys/sysmacros.h>
 
+#include <algorithm>
+#include <cstring>
 #include <list>
+#include <map>
+#include <mutex>
 #include <regex>
 
 #include <linux/media.h>
@@ -25,6 +29,7 @@
 #include "logger/LoggerInterval.hpp"
 #include "exception/ObException.hpp"
 #include "frame/FrameFactory.hpp"
+#include "utils/GmslMetadataTrace.hpp"
 
 #include <iostream>
 #include <chrono>
@@ -630,6 +635,8 @@ void writeBufferToFile(const char *buf, std::size_t size, const std::string &fil
 void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHandle) {
     int metadataBufferIndex = -1;
     int colorFrameNum       = 0;  // color drop 1~3 frame -> fix color green screen issue.
+    utils::GmslMetadataTrace::V4lTrace metadataTrace(devHandle->info->name, devHandle->profile->getType(), MAX_BUFFER_COUNT_GMSL,
+                                                     utils::GmslMetadataTrace::MetadataFormat::G330_96B);
 
     devHandle->loopFrameIndex.store(1);  // frame number start from 1
     try {
@@ -714,6 +721,10 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
                     devHandle->metadataBuffers[buf.index].actual_length = buf.bytesused;
                     devHandle->metadataBuffers[buf.index].sequence      = buf.sequence;
                     metadataBufferIndex                                 = buf.index;
+                    if(metadataTrace.enabled() && buf.index < devHandle->metadataBuffers.size()) {
+                        auto &metaBuf = devHandle->metadataBuffers[buf.index];
+                        metadataTrace.recordMetadataDequeued(buf.index, buf.sequence, buf.bytesused, metaBuf.ptr, metaBuf.length);
+                    }
                 }
 
                 if(devHandle->isCapturing) {
@@ -740,6 +751,10 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
                     TRY_EXECUTE({
                         auto rawframe   = FrameFactory::createFrameFromStreamProfile(devHandle->profile);
                         auto videoFrame = rawframe->as<VideoFrame>();
+                        uint32_t metadataTraceSeq               = 0;
+                        uint32_t metadataTraceBytes             = 0;
+                        uint32_t metadataTracePresentationTime  = 0;
+                        const void *metadataTraceData           = nullptr;
                         // if((DetectPlatform() == Platform::Xavier) || (DetectPlatform() == Platform::Orin))
                         if(1 > 0)  // Modify the default setting to apply special resolution processing to all NVIDIA platforms
                         {
@@ -754,12 +769,16 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
                             auto &metaBuf                = devHandle->metadataBuffers[metadataBufferIndex];
                             auto  uvc_payload_header     = metaBuf.ptr;
                             auto  uvc_payload_header_len = metaBuf.actual_length;
+                            metadataTraceSeq   = metaBuf.sequence;
+                            metadataTraceBytes = uvc_payload_header_len;
+                            metadataTraceData  = uvc_payload_header;
                             videoFrame->updateMetadata(static_cast<const uint8_t *>(uvc_payload_header), 12);
                             videoFrame->appendMetadata(static_cast<const uint8_t *>(uvc_payload_header), uvc_payload_header_len);
 
                             if(uvc_payload_header_len >= sizeof(StandardUvcFramePayloadHeader)) {
                                 auto payloadHeader = (StandardUvcFramePayloadHeader *)uvc_payload_header;
                                 videoFrame->setTimeStampUsec(payloadHeader->dwPresentationTime);
+                                metadataTracePresentationTime = payloadHeader->dwPresentationTime;
                             }
                         }
 
@@ -772,6 +791,9 @@ void ObV4lGmslDevicePort::captureLoop(std::shared_ptr<V4lDeviceHandleGmsl> devHa
 
                         // fix frame index zero issue.
                         videoFrame->setNumber(devHandle->loopFrameIndex);
+                        metadataTrace.logFrame(devHandle->loopFrameIndex.load(), buf.sequence, buf.bytesused, buf.index, metadataBufferIndex, metadataTraceSeq,
+                                               metadataTraceBytes, metadataTracePresentationTime, metadataTraceData, metadataTraceBytes,
+                                               devHandle->buffers[buf.index].ptr, buf.bytesused);
                         // LOG_DEBUG("set loopFrameIndex:{}", devHandle->loopFrameIndex);
 
                         if(devHandle->profile->getType() == OB_STREAM_COLOR) {

--- a/src/shared/utils/GmslMetadataTrace.cpp
+++ b/src/shared/utils/GmslMetadataTrace.cpp
@@ -75,6 +75,24 @@ uint8_t readG330PrependedByte(const void *data, size_t size, OBStreamType stream
     return metadataOffset < size ? ptr[metadataOffset] : 0;
 }
 
+bool hasG330PrependedBytes(const void *data, size_t size, OBStreamType streamType, size_t metadataOffset, size_t byteCount) {
+    if(!data || byteCount == 0) {
+        return false;
+    }
+
+    const size_t lastMetadataOffset = metadataOffset + byteCount - 1;
+    if(streamType == OB_STREAM_COLOR || streamType == OB_STREAM_COLOR_LEFT || streamType == OB_STREAM_COLOR_RIGHT) {
+        if(size < 2) {
+            return false;
+        }
+        return lastMetadataOffset <= (size - 2) / 2;
+    }
+    if(streamType == OB_STREAM_DEPTH) {
+        return lastMetadataOffset <= (size - 1) / 2;
+    }
+    return lastMetadataOffset < size;
+}
+
 uint32_t readG330PrependedLe32(const void *data, size_t size, OBStreamType streamType, size_t metadataOffset) {
     return static_cast<uint32_t>(readG330PrependedByte(data, size, streamType, metadataOffset))
            | (static_cast<uint32_t>(readG330PrependedByte(data, size, streamType, metadataOffset + 1)) << 8)
@@ -84,7 +102,7 @@ uint32_t readG330PrependedLe32(const void *data, size_t size, OBStreamType strea
 
 MetadataFields readG330PrependedMetadata(const void *data, size_t size, OBStreamType streamType) {
     MetadataFields fields;
-    if(!data || size == 0) {
+    if(!hasG330PrependedBytes(data, size, streamType, G330_OFFSET_USEC_OFFSET, sizeof(uint32_t))) {
         return fields;
     }
 
@@ -203,7 +221,11 @@ bool isEnabled() {
 }
 
 V4lTrace::V4lTrace(std::string devName, OBStreamType streamType, size_t metadataBufferCount, MetadataFormat metadataFormat)
-    : devName_(std::move(devName)), streamType_(streamType), metadataFormat_(metadataFormat), enabled_(isEnabled()), snapshots_(metadataBufferCount) {}
+    : devName_(std::move(devName)),
+      streamType_(streamType),
+      metadataFormat_(metadataFormat),
+      enabled_(isEnabled()),
+      snapshots_(enabled_ ? metadataBufferCount : 0) {}
 
 bool V4lTrace::enabled() const {
     return enabled_;

--- a/src/shared/utils/GmslMetadataTrace.cpp
+++ b/src/shared/utils/GmslMetadataTrace.cpp
@@ -1,0 +1,338 @@
+// Copyright (c) Orbbec Inc. All Rights Reserved.
+// Licensed under the MIT License.
+
+#include "GmslMetadataTrace.hpp"
+
+#include "logger/Logger.hpp"
+
+#include <algorithm>
+#include <cstdlib>
+#include <cstring>
+#include <map>
+#include <mutex>
+#include <utility>
+
+namespace libobsensor {
+namespace utils {
+namespace GmslMetadataTrace {
+
+namespace {
+
+constexpr size_t G330_UVC_HEADER_BYTES = 12;
+
+constexpr size_t G330_FRAME_COUNTER_OFFSET = 0;
+constexpr size_t G330_SOF_SEC_OFFSET       = 12;
+constexpr size_t G330_SOF_NSEC_OFFSET      = 16;
+constexpr size_t G330_EXPOSURE_OFFSET      = 20;
+constexpr size_t G330_BITMAP_OFFSET        = 52;
+constexpr size_t G330_OFFSET_USEC_OFFSET   = 56;
+
+struct MetadataFields {
+    bool valid = false;
+
+    uint32_t frameCounter = 0;
+    uint32_t sofSec       = 0;
+    uint32_t sofNsec      = 0;
+    uint32_t exposure     = 0;
+    uint32_t bitmap       = 0;
+    uint32_t offsetUsec   = 0;
+};
+
+struct ModifierState {
+    bool     hasLastFrameCounter = false;
+    uint32_t lastFrameCounter    = 0;
+    uint64_t lastSdkNumber       = 0;
+    uint32_t sampleCount         = 0;
+};
+
+std::mutex                          modifierMutex;
+std::map<OBFrameType, ModifierState> modifierStates;
+
+uint32_t readLe32(const void *data, size_t size, size_t offset) {
+    if(!data || offset + 4 > size) {
+        return 0;
+    }
+
+    auto ptr = static_cast<const uint8_t *>(data) + offset;
+    return static_cast<uint32_t>(ptr[0]) | (static_cast<uint32_t>(ptr[1]) << 8) | (static_cast<uint32_t>(ptr[2]) << 16)
+           | (static_cast<uint32_t>(ptr[3]) << 24);
+}
+
+uint8_t readG330PrependedByte(const void *data, size_t size, OBStreamType streamType, size_t metadataOffset) {
+    if(!data) {
+        return 0;
+    }
+
+    auto ptr = static_cast<const uint8_t *>(data);
+    if(streamType == OB_STREAM_COLOR || streamType == OB_STREAM_COLOR_LEFT || streamType == OB_STREAM_COLOR_RIGHT) {
+        const size_t srcOffset = metadataOffset * 2 + 1;
+        return srcOffset < size ? ptr[srcOffset] : 0;
+    }
+    if(streamType == OB_STREAM_DEPTH) {
+        const size_t srcOffset = metadataOffset * 2;
+        return srcOffset < size ? ptr[srcOffset] : 0;
+    }
+    return metadataOffset < size ? ptr[metadataOffset] : 0;
+}
+
+uint32_t readG330PrependedLe32(const void *data, size_t size, OBStreamType streamType, size_t metadataOffset) {
+    return static_cast<uint32_t>(readG330PrependedByte(data, size, streamType, metadataOffset))
+           | (static_cast<uint32_t>(readG330PrependedByte(data, size, streamType, metadataOffset + 1)) << 8)
+           | (static_cast<uint32_t>(readG330PrependedByte(data, size, streamType, metadataOffset + 2)) << 16)
+           | (static_cast<uint32_t>(readG330PrependedByte(data, size, streamType, metadataOffset + 3)) << 24);
+}
+
+MetadataFields readG330PrependedMetadata(const void *data, size_t size, OBStreamType streamType) {
+    MetadataFields fields;
+    if(!data || size == 0) {
+        return fields;
+    }
+
+    fields.valid        = true;
+    fields.frameCounter = readG330PrependedLe32(data, size, streamType, G330_FRAME_COUNTER_OFFSET);
+    fields.sofSec       = readG330PrependedLe32(data, size, streamType, G330_SOF_SEC_OFFSET);
+    fields.sofNsec      = readG330PrependedLe32(data, size, streamType, G330_SOF_NSEC_OFFSET);
+    fields.exposure     = readG330PrependedLe32(data, size, streamType, G330_EXPOSURE_OFFSET);
+    fields.bitmap       = readG330PrependedLe32(data, size, streamType, G330_BITMAP_OFFSET);
+    fields.offsetUsec   = readG330PrependedLe32(data, size, streamType, G330_OFFSET_USEC_OFFSET);
+    return fields;
+}
+
+MetadataFields readG330FrameMetadata(const uint8_t *metadata, size_t size) {
+    MetadataFields fields;
+    if(!metadata || size < G330_UVC_HEADER_BYTES + G330_OFFSET_USEC_OFFSET + sizeof(uint32_t)) {
+        return fields;
+    }
+
+    fields.valid        = true;
+    fields.frameCounter = readLe32(metadata, size, G330_UVC_HEADER_BYTES + G330_FRAME_COUNTER_OFFSET);
+    fields.sofSec       = readLe32(metadata, size, G330_UVC_HEADER_BYTES + G330_SOF_SEC_OFFSET);
+    fields.sofNsec      = readLe32(metadata, size, G330_UVC_HEADER_BYTES + G330_SOF_NSEC_OFFSET);
+    fields.exposure     = readLe32(metadata, size, G330_UVC_HEADER_BYTES + G330_EXPOSURE_OFFSET);
+    fields.bitmap       = readLe32(metadata, size, G330_UVC_HEADER_BYTES + G330_BITMAP_OFFSET);
+    fields.offsetUsec   = readLe32(metadata, size, G330_UVC_HEADER_BYTES + G330_OFFSET_USEC_OFFSET);
+    return fields;
+}
+
+const char *metadataFormatName(MetadataFormat format) {
+    switch(format) {
+    case MetadataFormat::G330_96B:
+        return "g330_96b";
+    default:
+        return "unknown";
+    }
+}
+
+MetadataFields readPrependedMetadata(MetadataFormat format, const void *data, size_t size, OBStreamType streamType) {
+    switch(format) {
+    case MetadataFormat::G330_96B:
+        return readG330PrependedMetadata(data, size, streamType);
+    default:
+        return {};
+    }
+}
+
+void copySnapshot(MetadataSnapshot &snapshot, uint32_t index, uint32_t sequence, uint32_t bytesUsed, const void *data, size_t size) {
+    snapshot.valid     = true;
+    snapshot.index     = index;
+    snapshot.sequence  = sequence;
+    snapshot.bytesUsed = bytesUsed;
+    snapshot.copied    = 0;
+
+    if(!data) {
+        return;
+    }
+
+    snapshot.copied = static_cast<uint32_t>(std::min(std::min(static_cast<size_t>(bytesUsed), size), METADATA_SNAPSHOT_BYTES));
+    if(snapshot.copied > 0) {
+        std::memcpy(snapshot.bytes, data, snapshot.copied);
+    }
+}
+
+bool snapshotEquals(const MetadataSnapshot &snapshot, const void *data, size_t size) {
+    if(!snapshot.valid || !data || snapshot.copied == 0 || size < snapshot.copied) {
+        return false;
+    }
+    return std::memcmp(snapshot.bytes, data, snapshot.copied) == 0;
+}
+
+std::string hexPrefix(const void *data, size_t size, size_t maxBytes) {
+    if(!data || size == 0 || maxBytes == 0) {
+        return "";
+    }
+
+    static constexpr char HEX[] = "0123456789abcdef";
+    auto                  ptr   = static_cast<const uint8_t *>(data);
+    const size_t          count = std::min(size, maxBytes);
+
+    std::string out;
+    out.reserve(count * 3);
+    for(size_t i = 0; i < count; ++i) {
+        if(i > 0) {
+            out.push_back(':');
+        }
+        out.push_back(HEX[(ptr[i] >> 4) & 0x0f]);
+        out.push_back(HEX[ptr[i] & 0x0f]);
+    }
+    return out;
+}
+
+void appendFlag(std::string &flags, const char *flag) {
+    if(!flags.empty()) {
+        flags.push_back('|');
+    }
+    flags += flag;
+}
+
+int64_t sofUsec(const MetadataFields &fields) {
+    return static_cast<int64_t>(fields.sofSec) * 1000000 + static_cast<int64_t>(fields.sofNsec) / 1000 - static_cast<int64_t>(fields.offsetUsec);
+}
+
+}  // namespace
+
+bool isEnabled() {
+    static const bool enabled = [] {
+        const char *value = std::getenv("OB_GMSL_METADATA_TRACE");
+        if(!value) {
+            return false;
+        }
+        return std::strcmp(value, "1") == 0 || std::strcmp(value, "true") == 0 || std::strcmp(value, "TRUE") == 0 || std::strcmp(value, "on") == 0
+               || std::strcmp(value, "ON") == 0;
+    }();
+    return enabled;
+}
+
+V4lTrace::V4lTrace(std::string devName, OBStreamType streamType, size_t metadataBufferCount, MetadataFormat metadataFormat)
+    : devName_(std::move(devName)), streamType_(streamType), metadataFormat_(metadataFormat), enabled_(isEnabled()), snapshots_(metadataBufferCount) {}
+
+bool V4lTrace::enabled() const {
+    return enabled_;
+}
+
+void V4lTrace::recordMetadataDequeued(uint32_t index, uint32_t sequence, uint32_t bytesUsed, const void *data, size_t size) {
+    if(!enabled_ || index >= snapshots_.size()) {
+        return;
+    }
+    copySnapshot(snapshots_[index], index, sequence, bytesUsed, data, size);
+}
+
+void V4lTrace::logFrame(uint64_t loopIndex, uint32_t videoSeq, uint32_t videoBytes, uint32_t videoIndex, int metadataIndex, uint32_t metadataSeq,
+                        uint32_t metadataBytes, uint32_t payloadDwPresentationTime, const void *metadataData, size_t metadataSize, const void *imageData,
+                        size_t imageSize) {
+    if(!enabled_) {
+        return;
+    }
+
+    const auto embeddedFields = readPrependedMetadata(metadataFormat_, imageData, imageSize, streamType_);
+
+    const bool videoSeqJump = hasLastVideoSeq_ && videoSeq != lastVideoSeq_ + 1;
+    const bool metaSeqJump  = metadataIndex >= 0 && hasLastMetadataSeq_ && metadataSeq != lastMetadataSeq_ + 1;
+    const bool loopJump     = sampleCount_ > 0 && loopIndex != lastLoopIndex_ + 1;
+    const bool embeddedCounterRepeat = embeddedFields.valid && hasLastEmbeddedCounter_ && embeddedFields.frameCounter == lastEmbeddedCounter_;
+    const bool embeddedCounterJump = embeddedFields.valid && hasLastEmbeddedCounter_ && embeddedFields.frameCounter > lastEmbeddedCounter_ + 1;
+
+    const MetadataSnapshot *snapshot = nullptr;
+    if(metadataIndex >= 0 && static_cast<size_t>(metadataIndex) < snapshots_.size() && snapshots_[metadataIndex].valid) {
+        snapshot = &snapshots_[metadataIndex];
+    }
+    const bool snapshotLaterEqual = snapshot && snapshotEquals(*snapshot, metadataData, metadataSize);
+    const bool snapshotLaterDiff  = snapshot && metadataData && !snapshotLaterEqual;
+
+    const bool shouldLog = sampleCount_ < 12 || videoSeqJump || metaSeqJump || loopJump || embeddedCounterRepeat || embeddedCounterJump || snapshotLaterDiff;
+    if(shouldLog) {
+        std::string flags;
+        if(videoSeqJump) {
+            appendFlag(flags, "video_seq_jump");
+        }
+        if(metaSeqJump) {
+            appendFlag(flags, "meta_seq_jump");
+        }
+        if(loopJump) {
+            appendFlag(flags, "loop_jump");
+        }
+        if(embeddedCounterRepeat) {
+            appendFlag(flags, "embedded_counter_repeat");
+        }
+        if(embeddedCounterJump) {
+            appendFlag(flags, "embedded_counter_jump");
+        }
+        if(snapshotLaterDiff) {
+            appendFlag(flags, "dqbuf_later_hex_diff");
+        }
+
+        const auto dVideoSeq       = hasLastVideoSeq_ ? static_cast<int64_t>(videoSeq) - static_cast<int64_t>(lastVideoSeq_) : 0;
+        const auto dMetadataSeq    = hasLastMetadataSeq_ ? static_cast<int64_t>(metadataSeq) - static_cast<int64_t>(lastMetadataSeq_) : 0;
+        const auto dEmbeddedCount  = hasLastEmbeddedCounter_ ? static_cast<int64_t>(embeddedFields.frameCounter) - static_cast<int64_t>(lastEmbeddedCounter_) : 0;
+        const auto embeddedSofTime = embeddedFields.valid ? sofUsec(embeddedFields) : 0;
+        const auto dEmbeddedSofMs  = hasLastEmbeddedCounter_ ? (embeddedSofTime - lastEmbeddedSofUsec_) / 1000.0 : 0.0;
+
+        LOG_INFO("GMSL metadata trace source=v4l dev={} streamType={} loopIndex={} videoSeq={} dVideoSeq={} videoBufIndex={} videoBytes={} "
+                  "metadataIndex={} metaSeq={} dMetaSeq={} metaLen={} metaFirstU32={} payloadDwPresentationTime={} dqbufMetaSeq={} dqbufMetaLen={} "
+                  "dqbufMetaCopied={} dqbufMetaHex={} laterMetaHex={} dqbufLaterHexEqual={} embeddedFormat={} embeddedFrameCounter={} "
+                  "dEmbeddedFrameCounter={} embeddedSofSec={} embeddedSofNsec={} embeddedExposure={} embeddedBitmap=0x{:x} embeddedOffsetUsec={} "
+                  "embeddedSofUsec={} dEmbeddedSofMs={} flags={}",
+                  devName_, static_cast<int>(streamType_), loopIndex, videoSeq, dVideoSeq, videoIndex, videoBytes, metadataIndex, metadataSeq, dMetadataSeq,
+                  metadataBytes, readLe32(metadataData, metadataSize, 0), payloadDwPresentationTime, snapshot ? snapshot->sequence : 0,
+                  snapshot ? snapshot->bytesUsed : 0, snapshot ? snapshot->copied : 0,
+                  snapshot ? hexPrefix(snapshot->bytes, snapshot->copied, METADATA_SNAPSHOT_BYTES) : "",
+                  hexPrefix(metadataData, metadataSize, METADATA_SNAPSHOT_BYTES), snapshot ? (snapshotLaterEqual ? 1 : 0) : -1, metadataFormatName(metadataFormat_),
+                  embeddedFields.frameCounter, dEmbeddedCount, embeddedFields.sofSec, embeddedFields.sofNsec, embeddedFields.exposure,
+                  embeddedFields.bitmap, embeddedFields.offsetUsec, embeddedSofTime, dEmbeddedSofMs, flags.empty() ? "none" : flags.c_str());
+    }
+
+    hasLastVideoSeq_ = true;
+    lastVideoSeq_    = videoSeq;
+    if(metadataIndex >= 0) {
+        hasLastMetadataSeq_ = true;
+        lastMetadataSeq_    = metadataSeq;
+    }
+    if(embeddedFields.valid) {
+        hasLastEmbeddedCounter_ = true;
+        lastEmbeddedCounter_    = embeddedFields.frameCounter;
+        lastEmbeddedSofUsec_    = sofUsec(embeddedFields);
+    }
+    lastLoopIndex_ = loopIndex;
+    sampleCount_++;
+}
+
+void logG330ModifierFrame(OBFrameType frameType, uint64_t sdkNumber, const uint8_t *metadata, size_t metadataSize) {
+    if(!isEnabled()) {
+        return;
+    }
+
+    const auto fields = readG330FrameMetadata(metadata, metadataSize);
+
+    std::lock_guard<std::mutex> lock(modifierMutex);
+    auto                       &state = modifierStates[frameType];
+    const bool                  repeated = fields.valid && state.hasLastFrameCounter && fields.frameCounter == state.lastFrameCounter;
+    const bool                  jumped   = fields.valid && state.hasLastFrameCounter && fields.frameCounter > state.lastFrameCounter + 1;
+    const bool                  shouldLog = state.sampleCount < 12 || repeated || jumped;
+
+    if(shouldLog) {
+        std::string flags;
+        if(repeated) {
+            appendFlag(flags, "frame_counter_repeat");
+        }
+        if(jumped) {
+            appendFlag(flags, "frame_counter_jump");
+        }
+
+        LOG_INFO("GMSL metadata trace source=modifier metadataFormat=g330 frameType={} sdkNumber={} dSdkNumber={} mdFrameCounter={} dMdFrameCounter={} "
+                  "sofSec={} sofNsec={} exposure={} bitmap=0x{:x} offsetUsec={} flags={}",
+                  static_cast<int>(frameType), sdkNumber,
+                  state.sampleCount > 0 ? static_cast<int64_t>(sdkNumber) - static_cast<int64_t>(state.lastSdkNumber) : 0, fields.frameCounter,
+                  state.hasLastFrameCounter ? static_cast<int64_t>(fields.frameCounter) - static_cast<int64_t>(state.lastFrameCounter) : 0, fields.sofSec,
+                  fields.sofNsec, fields.exposure, fields.bitmap, fields.offsetUsec, flags.empty() ? "none" : flags.c_str());
+    }
+
+    if(fields.valid) {
+        state.hasLastFrameCounter = true;
+        state.lastFrameCounter    = fields.frameCounter;
+    }
+    state.lastSdkNumber = sdkNumber;
+    state.sampleCount++;
+}
+
+}  // namespace GmslMetadataTrace
+}  // namespace utils
+}  // namespace libobsensor

--- a/src/shared/utils/GmslMetadataTrace.hpp
+++ b/src/shared/utils/GmslMetadataTrace.hpp
@@ -1,0 +1,70 @@
+// Copyright (c) Orbbec Inc. All Rights Reserved.
+// Licensed under the MIT License.
+
+#pragma once
+
+#include "libobsensor/h/ObTypes.h"
+
+#include <cstddef>
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace libobsensor {
+namespace utils {
+namespace GmslMetadataTrace {
+
+constexpr size_t METADATA_SNAPSHOT_BYTES = 96;
+
+bool isEnabled();
+
+enum class MetadataFormat {
+    G330_96B,
+};
+
+struct MetadataSnapshot {
+    bool valid = false;
+
+    uint32_t index     = 0;
+    uint32_t sequence  = 0;
+    uint32_t bytesUsed = 0;
+    uint32_t copied    = 0;
+
+    uint8_t bytes[METADATA_SNAPSHOT_BYTES] = {};
+};
+
+class V4lTrace {
+public:
+    V4lTrace(std::string devName, OBStreamType streamType, size_t metadataBufferCount, MetadataFormat metadataFormat = MetadataFormat::G330_96B);
+
+    bool enabled() const;
+
+    void recordMetadataDequeued(uint32_t index, uint32_t sequence, uint32_t bytesUsed, const void *data, size_t size);
+
+    void logFrame(uint64_t loopIndex, uint32_t videoSeq, uint32_t videoBytes, uint32_t videoIndex, int metadataIndex, uint32_t metadataSeq,
+                  uint32_t metadataBytes, uint32_t payloadDwPresentationTime, const void *metadataData, size_t metadataSize, const void *imageData,
+                  size_t imageSize);
+
+private:
+    std::string                   devName_;
+    OBStreamType                  streamType_;
+    MetadataFormat                metadataFormat_;
+    bool                          enabled_ = false;
+    std::vector<MetadataSnapshot> snapshots_;
+
+    bool     hasLastVideoSeq_        = false;
+    bool     hasLastMetadataSeq_     = false;
+    bool     hasLastEmbeddedCounter_ = false;
+    uint32_t lastVideoSeq_           = 0;
+    uint32_t lastMetadataSeq_        = 0;
+    uint32_t lastEmbeddedCounter_    = 0;
+    int64_t  lastEmbeddedSofUsec_    = 0;
+    uint64_t lastLoopIndex_          = 0;
+    uint32_t sampleCount_            = 0;
+};
+
+void logG330ModifierFrame(OBFrameType frameType, uint64_t sdkNumber, const uint8_t *metadata, size_t metadataSize);
+
+}  // namespace GmslMetadataTrace
+}  // namespace utils
+}  // namespace libobsensor


### PR DESCRIPTION
## Summary

This PR adds a default-off SDK-internal diagnostic trace for GMSL metadata/timestamp investigations on Jetson platforms.

It is intended to help separate three classes of failures without changing normal capture behavior:

- V4L metadata side-channel buffer lifetime/read timing problems
- platform driver/firmware metadata generation problems
- SDK metadata modifier / frame binding propagation problems

The trace is gated by `OB_GMSL_METADATA_TRACE=1`. When the variable is not set, no trace lines are emitted and the normal capture path is unchanged.

## Design

- Adds `src/shared/utils/GmslMetadataTrace.{hpp,cpp}` as the single diagnostic component.
- Keeps hot-path changes small:
  - `ObV4lGmslDevicePort.cpp` only creates a `V4lTrace`, records metadata DQBUF snapshots, and logs at frame binding time.
  - `G330MetadataModifier.cpp` only calls `logG330ModifierFrame()` after metadata is copied into the SDK frame.
- Uses the existing SDK logger (`LOG_INFO`) rather than stdout/stderr.
- Adds `MetadataFormat::G330_96B` so future GMSL metadata layouts can be added in one parser/helper boundary instead of scattering field offsets in capture code.

## What the trace shows

For V4L capture it can report:

- video sequence and buffer index
- metadata sequence, bytes used, and metadata buffer index
- DQBUF-time metadata snapshot hex vs later mmap-read hex
- G330 96-byte embedded metadata frame counter / SOF / exposure / bitmap / offset
- anomaly flags such as sequence jumps, embedded counter repeat/jump, and DQBUF/later hex mismatch

For the G330 metadata modifier it can report:

- SDK frame number
- metadata frame counter and delta
- SOF fields and timestamp offset after metadata has been copied into the SDK frame

## Validation

Validated on a Jetson AGX Orin GMSL setup where field logs showed stable average 30 FPS but intermittent application-layer timestamp/frame interval anomalies.

Build:

```bash
cd /home/nvidia/Desktop/orbbec_pr173_buildtest
cmake -S src_from_local -B build_pr173
cmake --build build_pr173 --target OrbbecSDK -j$(nproc)
```

Result:

```text
[100%] Built target OrbbecSDK
```

Default-off runtime smoke test:

```text
OB_GMSL_METADATA_TRACE unset
ob_quick_start under timeout 12s
TRACE_COUNT=0
```

Trace-on runtime smoke test:

```text
OB_GMSL_METADATA_TRACE=1
ob_quick_start under timeout 12s
TRACE_COUNT=230
V4L_COUNT=116
MODIFIER_COUNT=114
```

Example trace fields observed:

```text
GMSL metadata trace source=v4l ... embeddedFormat=g330_96b embeddedFrameCounter=2 ... dEmbeddedSofMs=0 flags=none
GMSL metadata trace source=modifier metadataFormat=g330 frameType=2 sdkNumber=4 ... mdFrameCounter=5 ... flags=none
```

Note: the validation machine was running the embedded-metadata driver mode, so metadata side-channel fields were naturally empty (`metadataIndex=-1`). The side-channel DQBUF snapshot comparison remains in the diagnostic component for driver modes that expose a metadata capture node.

## Notes for reviewers

This PR deliberately does not attempt to fix timestamp behavior. It adds a small diagnostic boundary so Orbbec SDK/platform maintainers can determine whether repeated/jumped metadata values are already present at V4L DQBUF time, appear only after later mmap reads, or are introduced after SDK metadata modification / frame binding.